### PR TITLE
Add version command

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -15,9 +15,15 @@ pub fn main() !void {
         return;
     }
 
-    // if args[1] is "--help" print the usage
-    if (std.mem.eql(u8, args[1], "--help")) {
+    const command = args[1];
+
+    // if command is "--help" print the usage
+    if (std.mem.eql(u8, command, "--help")) {
         try utils.printUsage();
+        return;
+    }
+    if (std.mem.eql(u8, command, "--version")) {
+        try utils.printVersion();
         return;
     }
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -15,6 +15,12 @@ pub fn printUsage() !void {
     try stdout.print("{s}\n", .{usage});
 }
 
+pub fn printVersion() !void {
+    const version = "NetScanner is still in development";
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("{s}\n", .{version});
+}
+
 pub fn ipStringToBytes(ip_string: []const u8) !([4]u8) {
     var ip_bytes: [4]u8 = undefined;
     var byte: u8 = 0;


### PR DESCRIPTION
Added functionality to handle `--version` command-line argument, printing the version of the tool using `utils.printVersion()` function.

### How to test?

Run the tool with the `--version` flag and verify that it prints the correct version information.

