### PR TITLE
Addded Windows check for scan IP

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,6 +11,11 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // Add libc dependency if on windows
+    if (target.result.os.tag == .windows) {
+        exe.linkLibC();
+    }
+
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const utils = @import("utils.zig");
 const scanner = @import("scanner.zig");
+const builtin = @import("builtin");
+const native_os = builtin.os.tag;
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -76,6 +78,10 @@ pub fn main() !void {
     }
     // if command is "-s"
     if (std.mem.eql(u8, command, "-s")) {
+        if (native_os == .windows) {
+            std.debug.print("NetScanner: This feature is not supported on Windows yet.\n", .{});
+            return;
+        }
         // read the next argument, which is the IP
         if (args.len < 3) {
             try utils.printUsage();

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -241,5 +241,7 @@ fn checksum(data: []const u8) u16 {
         sum = (sum & 0xFFFF) + (sum >> 16);
     }
 
-    return @intCast(~sum & 0xFFFF);
+    const checksum_result: u16 = @intCast(~sum & 0xFFFF);
+
+    return checksum_result;
 }


### PR DESCRIPTION
Unfortunately, windows requires different treatment when it comes to creating ICMP pings. You cannot create them manually (as I am attempting to here), as it complains about creating raw sockets (running as admin did not fix the issue).

To resolve this, we need to use the builtin windows iphlpapi functions for creating ICMP pings. After I figure out how to do it on Linux/Mac, I will move on to do this.