### PR TITLE
pivot towards builtin ping cmd

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,11 +11,6 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // Add libc dependency if on windows
-    if (target.result.os.tag == .windows) {
-        exe.linkLibC();
-    }
-
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);

--- a/src/main.zig
+++ b/src/main.zig
@@ -88,9 +88,8 @@ pub fn main() !void {
             return;
         }
         const ip_string = args[2];
-        const ip_bytes = try utils.ipStringToBytes(ip_string);
         std.debug.print("Scanning the network for host {s}\n", .{ip_string});
-        const pinged = try scanner.pingHost(ip_bytes);
+        const pinged = try scanner.pingHost(allocator, ip_string);
 
         if (pinged) {
             std.debug.print("Host is online\n", .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -78,23 +78,13 @@ pub fn main() !void {
     }
     // if command is "-s"
     if (std.mem.eql(u8, command, "-s")) {
-        if (native_os == .windows) {
-            std.debug.print("NetScanner: This feature is not supported on Windows yet.\n", .{});
-            return;
-        }
-        // read the next argument, which is the IP
+        // read the next argument, which is the cidr
         if (args.len < 3) {
             try utils.printUsage();
             return;
         }
-        const ip_string = args[2];
-        std.debug.print("Scanning the network for host {s}\n", .{ip_string});
-        const pinged = try scanner.pingHost(allocator, ip_string);
-
-        if (pinged) {
-            std.debug.print("Host is online\n", .{});
-        } else {
-            std.debug.print("Host is offline\n", .{});
-        }
+        const cidr = args[2];
+        std.debug.print("Scanning the network in range of {s}\n", .{cidr});
+        _ = try scanner.scanNetwork(allocator, cidr);
     }
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,5 +1,15 @@
 const std = @import("std");
 
+pub const Network = struct {
+    address: [4]u8,
+    prefix_len: u8,
+};
+
+pub const IpRange = struct {
+    start: [4]u8,
+    end: [4]u8,
+};
+
 pub fn printUsage() !void {
     const usage =
         \\ns <command>
@@ -60,6 +70,39 @@ pub fn ipStringToBytes(ip_string: []const u8) !([4]u8) {
     return ip_bytes;
 }
 
+pub fn ipBytesToString(ip_bytes: [4]u8) []const u8 {
+    // Initialize an array to hold the resulting string. The maximum length of an IP address in string form is 15 characters (including dots).
+    var ip_string: [15]u8 = undefined;
+    var index: usize = 0;
+
+    inline for (ip_bytes, 0..) |byte, i| {
+        if (i != 0) {
+            ip_string[index] = '.';
+            index += 1;
+        }
+        var byte_str = [3]u8{ 0, 0, 0 };
+        var byte_len: usize = 0;
+
+        var b = byte;
+        if (b == 0) {
+            byte_str[2] = '0';
+            byte_len = 1;
+        } else {
+            while (b != 0) : (b /= 10) {
+                byte_str[2 - byte_len] = '0' + (b % 10);
+                byte_len += 1;
+            }
+        }
+
+        for (byte_str[3 - byte_len .. 3]) |digit| {
+            ip_string[index] = digit;
+            index += 1;
+        }
+    }
+
+    return ip_string[0..index];
+}
+
 pub fn splitStringToIntArray(allocator: std.mem.Allocator, string: []const u8, delimiter: u8) !([]u16) {
     // Initial allocation with a size of 2
     var array: []u16 = try allocator.alloc(u16, 1);
@@ -107,6 +150,64 @@ pub fn splitStringToIntArray(allocator: std.mem.Allocator, string: []const u8, d
     array[array_index] = number;
 
     return array[0 .. array_index + 1];
+}
+
+pub fn parseCidr(cidr: []const u8) !Network {
+    var iter = std.mem.split(u8, cidr, "/");
+    const ip_str = iter.next() orelse return error.InvalidCidr;
+    const prefix_str = iter.next() orelse return error.InvalidCidr;
+
+    if (iter.next() != null) return error.InvalidCidr;
+
+    const address: [4]u8 = try ipStringToBytes(ip_str);
+
+    const prefix_len = try std.fmt.parseInt(u8, prefix_str, 10);
+    if (prefix_len > 32) return error.InvalidPrefixLength;
+
+    return Network{ .address = address, .prefix_len = prefix_len };
+}
+
+//TODO: FIX THIS
+pub fn getIpRange(network: Network) !IpRange {
+    const mask: u32 = computeMask(network.prefix_len);
+    const start_ip = (@as(u32, network.address[0]) << 24) | (@as(u32, network.address[1]) << 16) | (@as(u32, network.address[2]) << 8) | network.address[3];
+    const network_start = start_ip & mask;
+    const network_end = network_start | ~mask;
+
+    const start_ip_bytes = [4]u8{
+        @truncate((network_start >> 24) & 0xFF),
+        @truncate((network_start >> 16) & 0xFF),
+        @truncate((network_start >> 8) & 0xFF),
+        @truncate(network_start & 0xFF),
+    };
+
+    const end_ip_bytes = [4]u8{
+        @truncate((network_end >> 24) & 0xFF),
+        @truncate((network_end >> 16) & 0xFF),
+        @truncate((network_end >> 8) & 0xFF),
+        @truncate(network_end & 0xFF),
+    };
+
+    return IpRange{
+        .start = start_ip_bytes,
+        .end = end_ip_bytes,
+    };
+}
+
+fn computeMask(prefix_len: u8) u32 {
+    if (prefix_len == 32) {
+        return 0xFFFFFFFF;
+    } else {
+        return @as(u32, 0xFFFFFFFF) << @intCast(32 - prefix_len);
+    }
+}
+
+pub fn incrementIP(ip: *[4]u8) void {
+    var i: i32 = 3;
+    while (i >= 0) : (i -= 1) {
+        ip[@intCast(i)] +%= 1;
+        if (ip[@intCast(i)] != 0) break;
+    }
 }
 
 test "ipStringToBytes correctly translates IP string to byte array" {


### PR DESCRIPTION
Instead of creating the ICMP header and building the packet from scratch (which showed problems on both Linux and Windows), I have opted to use the ping API given by the OS.

The scanNetwork() function finally works as it is supposed to in both Windows and Linux.

Known issues:
- if the prefix length of the CIDR is greater than 32, this will crash the program. An error handler is needed to prevent the user from  entering a value bigger than 32, or smaller than 1.

Future developments:
- Save the online IP's in a list and print them out at the end
- Find a way to get the MAC address of the device that the address is tied to
- Find a way to get the name of the address

Refactoring is also needed for the main.zig. Some of the functions that are called in there could be brought out and made cleaner.